### PR TITLE
タイマー開始時のplayback was unable to startを修正

### DIFF
--- a/src/components/molecules/digit.module.scss
+++ b/src/components/molecules/digit.module.scss
@@ -1,7 +1,9 @@
 .root {
+  /*
   --seconds: 0;
   --minutes: 0;
   --iteration: 0;
+  */
   --font-size: 40px;
   display: flex;
   justify-content: center;
@@ -12,6 +14,7 @@
   height: var(--font-size);
 }
 
+/*
 .root::before,
 .root::after {
   display: block;
@@ -42,3 +45,4 @@
     transform: translate(0, calc(var(--font-size) * -60));
   }
 }
+*/

--- a/src/components/molecules/digit.tsx
+++ b/src/components/molecules/digit.tsx
@@ -17,7 +17,7 @@ const Digit: React.VFC<Props> = ({ seconds }) => {
   return (
     <>
       <Typography align={"center"} className={styles.root} style={style}>
-        :
+        {min + ":" + (sec < 10 ? "0" : "") + sec}
       </Typography>
     </>
   );

--- a/src/components/molecules/soundSlider.module.scss
+++ b/src/components/molecules/soundSlider.module.scss
@@ -9,7 +9,7 @@
 
 .slider{
   margin-right: 9px;
-  margin-left: 5px;
+  margin-left: 4px;
 }
 
 .thumb {

--- a/src/components/molecules/soundSlider.tsx
+++ b/src/components/molecules/soundSlider.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState, useEffect } from "react";
 import { Slider, Typography } from "@mui/material";
-import VolumeDownIcon from "@mui/icons-material/VolumeDown";
+import VolumeMuteIcon from '@mui/icons-material/VolumeMute';
 import VolumeUpIcon from "@mui/icons-material/VolumeUp";
 import { VolumeContext } from "../../pages/theme";
 import Timer2 from "../../../public/zihou1.mp3";
@@ -8,7 +8,7 @@ import { Howl } from "howler";
 import { MobileContext } from "../../pages/theme";
 import styles from "./soundSlider.module.scss";
 
-const DEFAULT_VOLUME = 100;
+const DEFAULT_VOLUME = 1;
 
 export default function ContinuousSlider() {
   const { volume, setVolume } = useContext(VolumeContext);
@@ -35,7 +35,7 @@ export default function ContinuousSlider() {
       localStorage.setItem("volume", newValue.toString());
       const sound = new Howl({
         src: [Timer2],
-        volume: newValue / 100,
+        volume: newValue,
         html5: true,
         sprite: {
           pi: [1800000, 2800],
@@ -47,7 +47,7 @@ export default function ContinuousSlider() {
       }
       sound.once("load", () => {
         sound.play("pi");
-        sound.volume(newValue / 100);
+        sound.volume(newValue);
       });
     }
   };
@@ -55,7 +55,7 @@ export default function ContinuousSlider() {
   return (
     <div className={styles.root}>
       <Typography>Sound</Typography>
-      <VolumeDownIcon />
+      <VolumeMuteIcon />
       <Slider
         classes={{
           root: styles.slider,
@@ -65,9 +65,11 @@ export default function ContinuousSlider() {
         }}
         aria-label="Volume"
         value={value}
+        max={1}
+        min={0}
         onChange={handleOnChange}
         onChangeCommitted={handleOnCommit}
-        step={useContext(MobileContext).isMobile ? 100 : 1}
+        step={useContext(MobileContext).isMobile ? 1 : 0.01}
       />
       <VolumeUpIcon className={styles.volumeUp} />
     </div>

--- a/src/components/organisms/timerButtons.tsx
+++ b/src/components/organisms/timerButtons.tsx
@@ -4,6 +4,7 @@ import styles from "./timerButtons.module.scss";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import IconButton from "@mui/material/IconButton";
 import SvgIcon from "@mui/material/SvgIcon";
+import { useSound } from "../../hooks/useSound";
 
 type Props = {
   isRunning: boolean;

--- a/src/components/templates/timer.tsx
+++ b/src/components/templates/timer.tsx
@@ -47,21 +47,18 @@ const Timer: React.VFC = () => {
       soundPath
     );
 
-  const [digitalTime, setDigitalTime] = useState(workTime);
   useEffect(() => {
     if (activity === "NextRest" || activity === "NextWork") {
       notifyMe(makeNotifyMessage(count, activity));
-      setDigitalTime(0);
-    } else if (activity === "Rest" || activity === "Work") {
-      setDigitalTime(displayTime);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [count, activity]);
 
+  /*
   useEffect(() => {
     setDigitalTime(displayTime);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [useWindowFocused().isFocused, status]);
+  */
 
   useEffect(() => {
     toastTomato();
@@ -95,7 +92,7 @@ const Timer: React.VFC = () => {
       />
       <div className={styles.container}>
         <TimerButtons timer={timer} isRunning={isRunning} status={status} />
-        <Digit seconds={digitalTime} key={activity + digitalTime.toString()} />
+        <Digit seconds={displayTime} />
         <TomatoSlider
           maxTime={
             activity === "Work" || activity === "None"

--- a/src/hooks/intervalTimerReducer/reducer.ts
+++ b/src/hooks/intervalTimerReducer/reducer.ts
@@ -1,6 +1,5 @@
 import { TimerActionsType } from './actions';
-import { State, StatusValues } from "../../types/intervalTimer"
-
+import { State, StatusValues } from "../../types/intervalTimer";
 /*1 count is 
   workTime -> delayTime -> restTime -> delayTime
 */
@@ -9,7 +8,7 @@ function minusToZero(time: number) {
   return time < 0 ? 0 : time;
 }
 
-export const getPrevCountTime = (st: State) => (st.workTime + st.restTime + st.delayTime * 2) * st.count 
+const getPrevCountTime = (st: State) => (st.workTime + st.restTime + st.delayTime * 2) * st.count 
 
 function calcActivity(st: State) {
   if (st.status === StatusValues.stopped || st.elapsedTime < st.delayTime) {
@@ -83,7 +82,7 @@ export function reducer(state: State, action: TimerActionsType): State {
       }
     }
     case 'start': {
-      document.documentElement.setAttribute('animation', 'running') 
+      document.documentElement.setAttribute('animation', 'running')
       return {
         ...state,
         elapsedTime: 0,

--- a/src/hooks/useIntervalTimer.ts
+++ b/src/hooks/useIntervalTimer.ts
@@ -1,13 +1,13 @@
 import { Timer, UseIntervalTimerReturn } from "../types/intervalTimer"
 import {
-  useRef,
   useEffect,
   useReducer,
   useCallback,
 } from "react";
-import { reducer, getPrevCountTime } from "./intervalTimerReducer/reducer";
-import { Howl } from "howler";
+import { reducer } from "./intervalTimerReducer/reducer";
 import { StatusValues } from "../types/intervalTimer";
+import { useSound } from "./useSound";
+
 export default Timer;
 
 
@@ -19,6 +19,7 @@ export const useIntervalTimer = (
   delayTime = 3,
   soundPath: string = "",
 ): UseIntervalTimerReturn => {
+  const {playSound, pauseSound, resumeSound, stopSound} = useSound(soundPath, volume);
   const [state, dispatch] = useReducer(reducer, {
     status: StatusValues.stopped,
     elapsedTime: 0,
@@ -32,63 +33,30 @@ export const useIntervalTimer = (
     displayTime: 0
   });
   const { status, elapsedTime } = state;
-  const soundRef = useRef<Howl>();
   const start = useCallback(() => {
     dispatch({ type: 'start' })
-  }, []);
+    playSound();
+  }, [playSound]);
 
   const pause = useCallback(() => {
     dispatch({ type: 'pause' });
-  }, []);
+    pauseSound();
+  }, [pauseSound]);
   const setTime = useCallback(() => {
     dispatch({ type: 'setTime' });
   }, []);
   const resume = useCallback(() => {
     dispatch({ type: 'resume' });
-  }, []);
+    resumeSound();
+  }, [resumeSound]);
   const stop = useCallback(() => {
     dispatch({ type: 'stop' });
-  }, []);
+    stopSound();
+  }, [stopSound]);
   const advance = useCallback((seconds: number) => {
     dispatch({ type: 'advance', payload: { seconds } });
   }, []);
 
-
-  useEffect(() => {
-
-
-    if (status === StatusValues.running && soundPath.length > 0 && soundRef.current == null) {
-      soundRef.current = new Howl({
-        src: [soundPath],
-        html5: true,
-        preload: false,
-      });
-      //onplayerror: () => alert('error'),
-      //onloaderror: () => alert('load error'),
-      soundRef.current.load();
-      soundRef.current.once("load", () => {
-        if (soundRef.current != null) {
-          soundRef.current.play();
-          soundRef.current.volume(volume / 100);
-        }
-      });
-    }
-    if (soundRef.current == null) {
-      return;
-    }
-    const sound: Howl = soundRef.current;
-    if (status === StatusValues.pause) {
-      sound.pause();
-    } else if (status === StatusValues.resume) {
-      sound.play();
-      sound.seek(state.elapsedTime - getPrevCountTime(state));
-    } else if (status === StatusValues.stopped) {
-      sound.unload();
-    }
-    return () => { if (sound.state() === "loaded") { sound.unload() } };
-  },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [status]);
 
 
   useEffect(() => {

--- a/src/hooks/useSound.ts
+++ b/src/hooks/useSound.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef, useCallback } from "react";
+import { Howl } from "howler";
+import { Sound } from "../types/sound"
+
+export const useSound = (soundPath: string, volume: number) : Sound => {
+  const soundRef = useRef<Howl>();
+  const pausedTimeRef = useRef(0);
+  if (volume < 0 || volume > 1) {
+    //throw new Error("volume error")
+  }
+
+  const play = useCallback(() => {
+    soundRef.current = new Howl({
+      src: [soundPath],
+      html5: true,
+      loop: true,
+      preload: false,
+      onplayerror: (id, message) => alert(id + ":" + message),
+    });
+    const sound = soundRef.current;
+    sound.load();
+    sound.once("load", () => {
+      if (sound != null) {
+        sound.volume(volume);
+        sound.play();
+      }
+    })
+  }, [soundPath, volume]);
+  const pause = useCallback(() => {
+    if(soundRef.current == null){
+      return;
+    }
+    pausedTimeRef.current = soundRef.current.seek();
+    soundRef.current.pause();
+  }, []);
+  const resume = useCallback(() => {
+    if(soundRef.current == null){
+      return;
+    }
+    soundRef.current.play();
+    soundRef.current.seek(pausedTimeRef.current);
+  }, []);
+  const stop = useCallback(() => {
+    if(soundRef.current == null){
+      return;
+    }
+    soundRef.current.stop();
+    soundRef.current.unload();
+  }, []);
+
+  useEffect( () => {
+    if(soundRef.current != null){
+      soundRef.current.volume(volume);
+    }
+  }, [volume])
+  return {playSound: play, pauseSound:pause, resumeSound: resume,  stopSound: stop}
+}

--- a/src/hooks/useWindowFocused.ts
+++ b/src/hooks/useWindowFocused.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+
 //import { WindowFocusContext } from "../../pages/theme";
 
 

--- a/src/types/sound.ts
+++ b/src/types/sound.ts
@@ -1,0 +1,6 @@
+export interface Sound{
+  playSound: () => void;
+  pauseSound: () => void;
+  resumeSound: () => void;
+  stopSound: () => void;
+}


### PR DESCRIPTION
iOSモバイルにてタイマー開始時にplayback was unable to startというエラーがhowler.jsで起こった。
結果、音が鳴らなかった。useEffect内にてサウンドを操作していたのが原因だった。
この部分をuseSoundとして切り分けた上で、タイマーのstart等のインターフェイスと紐付けした。
タイマーの操作とサウンドの操作を一致させるとエラーが回避できた。